### PR TITLE
Fix with cgroupfs and enable network namespace management

### DIFF
--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -254,7 +254,11 @@ ctr_stop_timeout = 30
 
 # manage_ns_lifecycle determines whether we pin and remove namespaces
 # and manage their lifecycle
+{% if kata_containers_enabled %}
+manage_ns_lifecycle = true
+{% else %}
 manage_ns_lifecycle = false
+{% endif %}
 
 # The directory where the state of the managed namespaces gets tracked.
 # Only used when manage_ns_lifecycle is true.

--- a/roles/container-engine/cri-o/templates/crio.conf.j2
+++ b/roles/container-engine/cri-o/templates/crio.conf.j2
@@ -110,7 +110,11 @@ decryption_keys_path = "/etc/crio/keys/"
 conmon = "{{ crio_conmon }}"
 
 # Cgroup setting for conmon
+{% if crio_cgroup_manager == "cgroupfs" %}
+conmon_cgroup = "pod"
+{% else %}
 conmon_cgroup = "system.slice"
+{% endif %}
 
 # Environment variable list for the conmon process, used for passing necessary
 # environment variables to conmon or the runtime.


### PR DESCRIPTION
__Cgroups compatibility__

When the _crio_cgroup_manager_ is set to _cgroupfs_, the option _conmon_cgroup_ must be set to _pod_ instead of _system.slice_, if not CRIO fails to start:

`level=fatal msg="Validating runtime config: cgroupfs manager conmon cgroup should be 'pod' or empty"`

__Network namespace management__

When KataContainers is enabled, _manage_ns_lifecycle_ should be set to _true_.

https://github.com/kata-containers/documentation/blob/master/how-to/run-kata-with-k8s.md#network-namespace-management